### PR TITLE
NGSTACK-532 add finding the correct php binary path

### DIFF
--- a/bundle/Command/GenerateProjectCommand.php
+++ b/bundle/Command/GenerateProjectCommand.php
@@ -12,6 +12,7 @@ use Netgen\Bundle\SiteGeneratorBundle\Generator\LegacySiteAccessGenerator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use function array_key_exists;
 use function class_exists;
@@ -245,9 +246,12 @@ class GenerateProjectCommand extends GeneratorCommand
 
             $this->output->writeln('');
 
+            $phpBinaryFinder = new PhpExecutableFinder();
+            $phpBinaryPath = $phpBinaryFinder->find();
+
             $this->runProcess(
                 [
-                    'php',
+                    $phpBinaryPath,
                     'bin/captainhook',
                     'install',
                     '--force',

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": "^7.4",
         "twig/twig": "^2.8.1",
         "symfony/framework-bundle": "^3.4 || ^4.2",
-        "symfony/console": "^3.4 || ^4.2"
+        "symfony/console": "^3.4 || ^4.2",
+        "symfony/process": "^3.4 || ^4.4 || ^5.0"
     },
     "conflict": {
         "netgen/block-manager": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "twig/twig": "^2.8.1",
         "symfony/framework-bundle": "^3.4 || ^4.2",
         "symfony/console": "^3.4 || ^4.2",
-        "symfony/process": "^3.4 || ^4.4 || ^5.0"
+        "symfony/process": "^3.4 || ^4.4"
     },
     "conflict": {
         "netgen/block-manager": "*",


### PR DESCRIPTION
When `php` defaults to php7.3 in projects where php7.4 is used Composer threw fatal error
`Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 7.4.1".`

This PR replaces using `php` with the php binary path which is found by `PhpExecutableFinder`.